### PR TITLE
ci(server): build multiplatform image (amd64 + arm64)

### DIFF
--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -83,6 +83,7 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
+          provenance: false
           push: true
           tags: |
             ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -56,6 +56,12 @@ jobs:
             exit 1
           fi
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -73,9 +79,10 @@ jobs:
             type=raw, value=${{ steps.version.outputs.version }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Add QEMU and Buildx setup and pass platforms: linux/amd64,linux/arm64 to the build step so a multi-arch manifest is pushed under each tag. Consumers on arm64 (M-series Macs, Graviton) now pull a native image automatically.